### PR TITLE
Merge Issue#6 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "jaac-test" extension will be documented in this file.
+All notable changes to the "jaac" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # jaac
 Just another auto complete
-# jaac-test README
+# jaac README
 
-This is the README for your extension "jaac-test". After writing up a brief description, we recommend including the following sections.
+This is the README for your extension "jaac". After writing up a brief description, we recommend including the following sections.
 
 ## Features
 

--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,15 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 
+const getResponse = async () => {
+	return new Promise((resolve, reject) => {
+		setTimeout(() => {
+		resolve("This is a test response");
+		}, 1000);
+	}).then(response => {
+		return response;
+	});
+}
 
 // This method is called when your extension is activated
 
@@ -23,9 +32,10 @@ function activate(context) {
 			const line = document.lineAt(position.line);
 			console.log(line.text);
 
-			// Generate
-			const snippetCompletion = new vscode.CompletionItem("Generate docs");
-			snippetCompletion.insertText = new vscode.SnippetString('\nThis is test');
+			// Generate docs here
+			const snippetCompletion = new vscode.CompletionItem('Generate docs');
+			var response = await getResponse();
+			snippetCompletion.insertText = new vscode.SnippetString('\n'+response);
 			return [
 				snippetCompletion
 			];

--- a/extension.js
+++ b/extension.js
@@ -17,13 +17,14 @@ const generateText = async (input) => {
 			extensionPath+'/venv/bin/python '
 			+extensionPath+'/processor/process.py'
 			+' --input="'+input+'"'
-			+' --doc="'+workSpacePath+'"', (err, stdout, stderr) => {
+			+' --doc="'+workSpacePath+'"', 
+			(err, stdout, stderr) => {
 				if (err) {
 					console.error(err);
 					resolve(ERROR);
 				} else if (stderr) {
 					console.error(stderr);
-					const substring = '[1m> Finished chain.[0m\n'
+					const substring = '[1m> Finished chain.[0m\n';
 					const output = stdout.substring(stdout.indexOf(substring) + substring.length) || '';
 					resolve(output);
 				}

--- a/extension.js
+++ b/extension.js
@@ -8,8 +8,25 @@ const BELOW = 'below';
 
 let extensionPath = '';
 
+// const jaacSettings = {
+// 	"jaacSettings.embeddings": "",
+// 	"jaacSettings.modelPath": ""
+// }
+
+// vscode.workspace.getConfiguration().registerConfigurationProvider("jaacSettings", {
+// 	provideConfiguration: async () => {
+// 		return jaacSettings;
+// 	}
+// }, vscode.ConfigurationTarget.Global);
+
 const generateText = async (input) => {
 	return new Promise((resolve, reject) => {
+
+		// const modelPath = vscode.workspace.getConfiguration("jaacSettings").get("jaacSettings.modelPath");
+		// const embeddings = vscode.workspace.getConfiguration("jaacSettings").get("jaacSettings.embeddings");
+		const modelPath = '';
+		const embeddings = '';
+		const prompt_yaml_path = '';
 
 		const workSpacePath = vscode.workspace.workspaceFolders[0].uri.fsPath;
 
@@ -17,7 +34,10 @@ const generateText = async (input) => {
 			extensionPath+'/venv/bin/python '
 			+extensionPath+'/processor/process.py'
 			+' --input="'+input+'"'
-			+' --doc="'+workSpacePath+'"', 
+			+' --doc="'+workSpacePath+'"'
+			+' --model_path="'+modelPath+'"'
+			+' --embedding="'+embeddings+'"'
+			+' --prompt_yaml_path="'+prompt_yaml_path+'"', 
 			(err, stdout, stderr) => {
 				if (err) {
 					console.error(err);
@@ -71,7 +91,6 @@ const executeGenerationCommand = (relative_pos) => {
 	});
 }
 
-// This method is called when your extension is activated
 /**
  * @param {vscode.ExtensionContext} context
  */

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,7 @@
 const vscode = require('vscode');
-const editor = vscode.window.activeTextEditor;
-const { exec } = require('child_process');
 const axios = require('axios');
+const { exec } = require('child_process');
+const editor = vscode.window.activeTextEditor;
 
 const STATUS_OK = 201;
 const ERROR = 'error';
@@ -10,8 +10,8 @@ const BELOW = 'below';
 
 let extensionPath = '';
 let workSpacePath = '';
-const settings = vscode.workspace.getConfiguration('jaac');
 
+const settings = vscode.workspace.getConfiguration('jaac');
 const modelPath = settings.get('modelPath') || '';
 const embeddings = settings.get('embeddings') || '';
 const prompt_yaml_path = settings.get('prompt_yaml_path') || '';
@@ -25,7 +25,6 @@ const callLlmApi = async (input) => {
 		prompt_yaml_path : prompt_yaml_path
 		
 	};
-
 	const response = await axios.post('http://127.0.0.1:5000', body);
 	return response;
 }

--- a/extension.js
+++ b/extension.js
@@ -3,12 +3,13 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 const editor = vscode.window.activeTextEditor;
-const util = require('util');
 const { exec } = require('child_process');
 
 const generateText = async (input) => {
 	return new Promise((resolve, reject) => {
-		exec('/Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/venv/bin/python /Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/processor/process.py --input="'+input+'"', (err, stdout, stderr) => {
+		exec('/Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/venv/bin/python '
+		+'/Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/processor/process.py'
+		+' --input="'+input+'"', (err, stdout, stderr) => {
 			if (err) {
 			  resolve(err);
 			} else {
@@ -31,6 +32,26 @@ const getText = () => {
 	return text;
 }
 
+const executeGenerationCommand = (pos) => {
+	const text = getText();
+	vscode.window.withProgress({
+		location: vscode.ProgressLocation.Window,
+		cancellable: false,
+		title: 'Generating doc'
+	}, async (progress) => {
+		progress.report({  increment: 0 });
+		const generatedText = await generateText(text);
+		const snippet = new vscode.SnippetString();
+		if (pos == "above") {
+			snippet.appendText(generatedText+"\n"+text);
+		} else {
+			snippet.appendText(text+"\n"+generatedText);
+		}
+		editor.insertSnippet(snippet);
+		progress.report({ increment: 100 });
+	});
+}
+
 // This method is called when your extension is activated
 /**
  * @param {vscode.ExtensionContext} context
@@ -38,7 +59,9 @@ const getText = () => {
 function activate(context) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	console.log('Congratulations, your extension "jaac" is now active!');
+	console.log('"Jaac" is active!');
+
+	
 
 	// const md = { scheme: 'file', language: 'markdown' };
 	// const md_provider = vscode.languages.registerCompletionItemProvider(md, {
@@ -67,11 +90,7 @@ function activate(context) {
 	const generate_docs_above_provider = vscode.commands.registerCommand(
 		"jaac.generate-doc-above",
 		async () => {
-			const text = getText();
-			const generatedText = await generateText(text);
-			const snippet = new vscode.SnippetString();
-			snippet.appendText(generatedText+"\n"+text);
-			editor.insertSnippet(snippet);
+			executeGenerationCommand("above")
 		}
 	);
 	
@@ -81,11 +100,7 @@ function activate(context) {
 	const generate_doc_below_provider = vscode.commands.registerCommand(
 		"jaac.generate-doc-below",
 		async () => {
-			const text = getText();
-			const generatedText = await generateText(text);
-			const snippet = new vscode.SnippetString();
-			snippet.appendText(text+"\n"+generatedText);
-			editor.insertSnippet(snippet);
+			executeGenerationCommand("below")
 		}
 	);
 	

--- a/extension.js
+++ b/extension.js
@@ -3,12 +3,18 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 const editor = vscode.window.activeTextEditor;
+const util = require('util');
+const { exec } = require('child_process');
 
 const getResponse = async () => {
 	return new Promise((resolve, reject) => {
-		setTimeout(() => {
-		resolve("This is a test response");
-		}, 1000);
+		exec('ls', (err, stdout, stderr) => {
+			if (err) {
+			  resolve(err);
+			} else {
+				resolve(stdout);
+			}
+		});
 	}).then(response => {
 		return response;
 	});

--- a/extension.js
+++ b/extension.js
@@ -6,9 +6,9 @@ const editor = vscode.window.activeTextEditor;
 const util = require('util');
 const { exec } = require('child_process');
 
-const getResponse = async () => {
+const generateText = async (input) => {
 	return new Promise((resolve, reject) => {
-		exec('ls', (err, stdout, stderr) => {
+		exec('/Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/venv/bin/python /Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/processor/process.py --input="'+input+'"', (err, stdout, stderr) => {
 			if (err) {
 			  resolve(err);
 			} else {
@@ -29,10 +29,6 @@ const getText = () => {
 		text = editor.document.getText(editor.selection);
 	}
 	return text;
-}
-
-const generateText = (context) => {
-	return getResponse();
 }
 
 // This method is called when your extension is activated

--- a/extension.js
+++ b/extension.js
@@ -7,9 +7,13 @@ const { exec } = require('child_process');
 
 const generateText = async (input) => {
 	return new Promise((resolve, reject) => {
+
+		const workSpacePath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+
 		exec('/Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/venv/bin/python '
 		+'/Users/prithvirajchaudhuri/Desktop/Other/Projects/jaac/processor/process.py'
-		+' --input="'+input+'"', (err, stdout, stderr) => {
+		+' --input="'+input+'"'
+		+' --doc="'+workSpacePath+'"', (err, stdout, stderr) => {
 			if (err) {
 			  resolve(err);
 			} else {
@@ -61,31 +65,6 @@ function activate(context) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	console.log('"Jaac" is active!');
-
-	
-
-	// const md = { scheme: 'file', language: 'markdown' };
-	// const md_provider = vscode.languages.registerCompletionItemProvider(md, {
-
-	// 	async provideCompletionItems(document, position, token, context) {
-
-	// 		// Get Text entered in the line
-	// 		const line = document.lineAt(position.line);
-	// 		console.log(line.text);
-
-	// 		// Generate docs here
-	// 		const snippetCompletion = new vscode.CompletionItem('Generate docs');
-	// 		var response = await getResponse();
-	// 		snippetCompletion.insertText = new vscode.SnippetString('\n'+response);
-	// 		return [
-	// 			snippetCompletion
-	// 		];
-
-	// 	}
-
-	// });
-
-	// context.subscriptions.push(md_provider);
 
 	//Right click menu with text selected generate doc above
 	const generate_docs_above_provider = vscode.commands.registerCommand(

--- a/extension.js
+++ b/extension.js
@@ -3,8 +3,8 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 
+
 // This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -12,36 +12,37 @@ const vscode = require('vscode');
 function activate(context) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "jaac-test" is now active!');
-
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('jaac-test.helloWorld', function () {
-		// The code you place here will be executed every time your command is executed
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from VSCode!');
-	});
-
-	context.subscriptions.push(disposable);
+	console.log('Congratulations, your extension "jaac" is now active!');
 
 	// Create a new disposable for creating a README File
-	let newDisposable = vscode.commands.registerCommand('jaac-test.writeReadme', function (){
-		const wsedit = new vscode.WorkspaceEdit();
-		const wsPath = vscode.workspace.workspaceFolders[0].uri.fsPath; // gets the path of the first workspace folder
-		const filePath = vscode.Uri.file(wsPath + '/README2.md');
-		const writeStr = '# Hello World!';
-		const writeData = Buffer.from(writeStr, 'utf8');
-		vscode.window.showInformationMessage(filePath.toString());
-		wsedit.createFile(filePath, { ignoreIfExists: true });
-		vscode.workspace.fs.writeFile(filePath, writeData);
-		vscode.workspace.applyEdit(wsedit);
-		vscode.window.showInformationMessage('Created a new file: README2.md');
+	// let newDisposable = vscode.commands.registerCommand('jaac.writeReadme', function (){
+	// 	const wsedit = new vscode.WorkspaceEdit();
+	// 	const wsPath = vscode.workspace.workspaceFolders[0].uri.fsPath; // gets the path of the first workspace folder
+	// 	const filePath = vscode.Uri.file(wsPath + '/README2.md');
+	// 	const writeStr = '# Hello World!';
+	// 	const writeData = Buffer.from(writeStr, 'utf8');
+	// 	vscode.window.showInformationMessage(filePath.toString());
+	// 	wsedit.createFile(filePath, { ignoreIfExists: true });
+	// 	vscode.workspace.fs.writeFile(filePath, writeData);
+	// 	vscode.workspace.applyEdit(wsedit);
+	// 	vscode.window.showInformationMessage('Created a new file: README2.md');
+	// });
+
+	const md = { scheme: 'file', language: 'markdown' };
+	const md_provider = vscode.languages.registerCompletionItemProvider(md, {
+
+		async provideCompletionItems(document, position, token, context) {
+			let title = "Sample"
+
+			const snippetCompletion = new vscode.CompletionItem('Title');
+			snippetCompletion.insertText = new vscode.SnippetString("This is a test string");
+			return [
+				snippetCompletion
+			];
+		}
 	});
 
-	context.subscriptions.push(newDisposable);
+	context.subscriptions.push(md_provider);
 
 }
 

--- a/extension.js
+++ b/extension.js
@@ -21,33 +21,34 @@ const generateText = async (input) => {
 	});
 }
 
-const getText = () => {
+const executeGenerationCommand = (relative_pos) => {
 	let text = '';
+	let range = null;
 	if (editor.selection.isSingleLine) {
 		const line = editor.document.lineAt(editor.selection.active);
 		text = line.text;
+		range = line.range;
 	} else {
 		text = editor.document.getText(editor.selection);
+		range = new vscode.Range(editor.selection.start, editor.selection.end);
 	}
-	return text;
-}
 
-const executeGenerationCommand = (pos) => {
-	const text = getText();
 	vscode.window.withProgress({
 		location: vscode.ProgressLocation.Window,
 		cancellable: false,
 		title: 'Generating doc'
 	}, async (progress) => {
 		progress.report({  increment: 0 });
+
 		const generatedText = await generateText(text);
 		const snippet = new vscode.SnippetString();
-		if (pos == "above") {
+		if (relative_pos == "above") {
 			snippet.appendText(generatedText+"\n"+text);
 		} else {
 			snippet.appendText(text+"\n"+generatedText);
 		}
-		editor.insertSnippet(snippet);
+		editor.insertSnippet(snippet, range);
+		
 		progress.report({ increment: 100 });
 	});
 }

--- a/extension.js
+++ b/extension.js
@@ -8,25 +8,14 @@ const BELOW = 'below';
 
 let extensionPath = '';
 
-// const jaacSettings = {
-// 	"jaacSettings.embeddings": "",
-// 	"jaacSettings.modelPath": ""
-// }
+const settings = vscode.workspace.getConfiguration('jaac');
 
-// vscode.workspace.getConfiguration().registerConfigurationProvider("jaacSettings", {
-// 	provideConfiguration: async () => {
-// 		return jaacSettings;
-// 	}
-// }, vscode.ConfigurationTarget.Global);
+const modelPath = settings.get('modelPath') || '';
+const embeddings = settings.get('embeddings') || '';
+const prompt_yaml_path = settings.get('prompt_yaml_path') || '';
 
 const generateText = async (input) => {
 	return new Promise((resolve, reject) => {
-
-		// const modelPath = vscode.workspace.getConfiguration("jaacSettings").get("jaacSettings.modelPath");
-		// const embeddings = vscode.workspace.getConfiguration("jaacSettings").get("jaacSettings.embeddings");
-		const modelPath = '';
-		const embeddings = '';
-		const prompt_yaml_path = '';
 
 		const workSpacePath = vscode.workspace.workspaceFolders[0].uri.fsPath;
 

--- a/extension.js
+++ b/extension.js
@@ -38,28 +38,28 @@ function activate(context) {
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	console.log('Congratulations, your extension "jaac" is now active!');
 
-	const md = { scheme: 'file', language: 'markdown' };
-	const md_provider = vscode.languages.registerCompletionItemProvider(md, {
+	// const md = { scheme: 'file', language: 'markdown' };
+	// const md_provider = vscode.languages.registerCompletionItemProvider(md, {
 
-		async provideCompletionItems(document, position, token, context) {
+	// 	async provideCompletionItems(document, position, token, context) {
 
-			// Get Text entered in the line
-			const line = document.lineAt(position.line);
-			console.log(line.text);
+	// 		// Get Text entered in the line
+	// 		const line = document.lineAt(position.line);
+	// 		console.log(line.text);
 
-			// Generate docs here
-			const snippetCompletion = new vscode.CompletionItem('Generate docs');
-			var response = await getResponse();
-			snippetCompletion.insertText = new vscode.SnippetString('\n'+response);
-			return [
-				snippetCompletion
-			];
+	// 		// Generate docs here
+	// 		const snippetCompletion = new vscode.CompletionItem('Generate docs');
+	// 		var response = await getResponse();
+	// 		snippetCompletion.insertText = new vscode.SnippetString('\n'+response);
+	// 		return [
+	// 			snippetCompletion
+	// 		];
 
-		}
+	// 	}
 
-	});
+	// });
 
-	context.subscriptions.push(md_provider);
+	// context.subscriptions.push(md_provider);
 
 	//Right click menu with text selected generate doc above
 	const generate_docs_above_provider = vscode.commands.registerCommand(

--- a/extension.js
+++ b/extension.js
@@ -2,11 +2,11 @@ const vscode = require('vscode');
 const editor = vscode.window.activeTextEditor;
 const { exec } = require('child_process');
 
-const ERROR = "error";
-const ABOVE = "above";
-const BELOW = "below";
+const ERROR = 'error';
+const ABOVE = 'above';
+const BELOW = 'below';
 
-let extensionPath = "";
+let extensionPath = '';
 
 const generateText = async (input) => {
 	return new Promise((resolve, reject) => {
@@ -23,7 +23,9 @@ const generateText = async (input) => {
 					resolve(ERROR);
 				} else if (stderr) {
 					console.error(stderr);
-					resolve(stdout);
+					const substring = '[1m> Finished chain.[0m\n'
+					const output = stdout.substring(stdout.indexOf(substring) + substring.length) || '';
+					resolve(output);
 				}
 			}
 		);
@@ -51,15 +53,15 @@ const executeGenerationCommand = (relative_pos) => {
 	}, async (progress) => {
 		progress.report({  increment: 0 });
 
-		const generatedText = await generateText(text);
+		const generatedText = await generateText(text.trim());
 		if (generatedText === ERROR) {
-			vscode.window.showErrorMessage("Could not generate documentation, there was an error");
+			vscode.window.showErrorMessage('Could not generate documentation, there was an error');
 		} else {
 			const snippet = new vscode.SnippetString();
 			if (relative_pos == ABOVE) {
-				snippet.appendText(generatedText+"\n"+text);
+				snippet.appendText(generatedText+'\n'+text);
 			} else {
-				snippet.appendText(text+"\n"+generatedText);
+				snippet.appendText(text+'\n'+generatedText);
 			}
 			editor.insertSnippet(snippet, range);
 		}
@@ -79,7 +81,7 @@ function activate(context) {
 
 	//Right click menu with text selected generate doc above
 	const generate_docs_above_provider = vscode.commands.registerCommand(
-		"jaac.generate-doc-above",
+		'jaac.generate-doc-above',
 		async () => {
 			executeGenerationCommand(ABOVE)
 		}
@@ -89,7 +91,7 @@ function activate(context) {
 
 	//Right click menu with text selected generate doc below
 	const generate_doc_below_provider = vscode.commands.registerCommand(
-		"jaac.generate-doc-below",
+		'jaac.generate-doc-below',
 		async () => {
 			executeGenerationCommand(BELOW)
 		}

--- a/extension.js
+++ b/extension.js
@@ -14,32 +14,24 @@ function activate(context) {
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	console.log('Congratulations, your extension "jaac" is now active!');
 
-	// Create a new disposable for creating a README File
-	// let newDisposable = vscode.commands.registerCommand('jaac.writeReadme', function (){
-	// 	const wsedit = new vscode.WorkspaceEdit();
-	// 	const wsPath = vscode.workspace.workspaceFolders[0].uri.fsPath; // gets the path of the first workspace folder
-	// 	const filePath = vscode.Uri.file(wsPath + '/README2.md');
-	// 	const writeStr = '# Hello World!';
-	// 	const writeData = Buffer.from(writeStr, 'utf8');
-	// 	vscode.window.showInformationMessage(filePath.toString());
-	// 	wsedit.createFile(filePath, { ignoreIfExists: true });
-	// 	vscode.workspace.fs.writeFile(filePath, writeData);
-	// 	vscode.workspace.applyEdit(wsedit);
-	// 	vscode.window.showInformationMessage('Created a new file: README2.md');
-	// });
-
 	const md = { scheme: 'file', language: 'markdown' };
 	const md_provider = vscode.languages.registerCompletionItemProvider(md, {
 
 		async provideCompletionItems(document, position, token, context) {
-			let title = "Sample"
 
-			const snippetCompletion = new vscode.CompletionItem('Title');
-			snippetCompletion.insertText = new vscode.SnippetString("This is a test string");
+			// Get Text entered in the line
+			const line = document.lineAt(position.line);
+			console.log(line.text);
+
+			// Generate
+			const snippetCompletion = new vscode.CompletionItem("Generate docs");
+			snippetCompletion.insertText = new vscode.SnippetString('\nThis is test');
 			return [
 				snippetCompletion
 			];
+
 		}
+
 	});
 
 	context.subscriptions.push(md_provider);

--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,7 @@
 
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
+const editor = vscode.window.activeTextEditor;
 
 const getResponse = async () => {
 	return new Promise((resolve, reject) => {
@@ -13,8 +14,22 @@ const getResponse = async () => {
 	});
 }
 
-// This method is called when your extension is activated
+const getText = () => {
+	let text = '';
+	if (editor.selection.isSingleLine) {
+		const line = editor.document.lineAt(editor.selection.active);
+		text = line.text;
+	} else {
+		text = editor.document.getText(editor.selection);
+	}
+	return text;
+}
 
+const generateText = (context) => {
+	return getResponse();
+}
+
+// This method is called when your extension is activated
 /**
  * @param {vscode.ExtensionContext} context
  */
@@ -45,6 +60,34 @@ function activate(context) {
 	});
 
 	context.subscriptions.push(md_provider);
+
+	//Right click menu with text selected generate doc above
+	const generate_docs_above_provider = vscode.commands.registerCommand(
+		"jaac.generate-doc-above",
+		async () => {
+			const text = getText();
+			const generatedText = await generateText(text);
+			const snippet = new vscode.SnippetString();
+			snippet.appendText(generatedText+"\n"+text);
+			editor.insertSnippet(snippet);
+		}
+	);
+	
+	context.subscriptions.push(generate_docs_above_provider);
+
+	//Right click menu with text selected generate doc below
+	const generate_doc_below_provider = vscode.commands.registerCommand(
+		"jaac.generate-doc-below",
+		async () => {
+			const text = getText();
+			const generatedText = await generateText(text);
+			const snippet = new vscode.SnippetString();
+			snippet.appendText(text+"\n"+generatedText);
+			editor.insertSnippet(snippet);
+		}
+	);
+	
+	context.subscriptions.push(generate_doc_below_provider);
 
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "jaac-test",
+  "name": "jaac",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "jaac-test",
+      "name": "jaac",
       "version": "0.0.1",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "jaac",
       "version": "0.0.1",
+      "dependencies": {
+        "axios": "^1.6.7"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",
@@ -421,6 +424,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -605,6 +623,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -665,6 +694,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -992,6 +1029,25 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -1006,6 +1062,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -1423,6 +1492,25 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -1791,6 +1879,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2770,6 +2863,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "requires": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2911,6 +3019,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2954,6 +3070,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "diff": {
       "version": "5.0.0",
@@ -3205,6 +3326,11 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
+    },
     "foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -3213,6 +3339,16 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -3522,6 +3658,19 @@
       "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -3793,6 +3942,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,30 @@
     "onStartupFinished"
   ],
   "main": "./extension.js",
-  "contributes": {},
+  "contributes": {
+    "commands": [
+      {
+        "command": "jaac.generate-doc-below",
+        "title": "Generate Documentation Below"
+      },
+      {
+        "command": "jaac.generate-doc-above",
+        "title": "Generate Documentation Above"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "jaac.generate-doc-below",
+          "group": "Jaac@1"
+        },
+        {
+          "command": "jaac.generate-doc-above",
+          "group": "Jaac@2"
+        }
+      ]
+    }
+  },
   "scripts": {
     "lint": "eslint .",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jaac-test",
-  "displayName": "jaac-test",
-  "description": "Just Another AutoComplete Test",
+  "name": "jaac",
+  "displayName": "jaac",
+  "description": "Just Another AutoComplete",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.86.0"
@@ -9,19 +9,11 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./extension.js",
-  "contributes": {
-    "commands": [{
-      "command": "jaac-test.helloWorld",
-      "title": "Hello World"
-    },
-    {
-      "command": "jaac-test.writeReadme",
-      "title": "Write README"
-    }
-  ]
-  },
+  "contributes": {},
   "scripts": {
     "lint": "eslint .",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,15 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.86.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "18.x",
-    "eslint": "^8.56.0",
-    "typescript": "^5.3.3",
+    "@types/vscode": "^1.86.0",
     "@vscode/test-cli": "^0.0.4",
-    "@vscode/test-electron": "^2.3.9"
+    "@vscode/test-electron": "^2.3.9",
+    "eslint": "^8.56.0",
+    "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "axios": "^1.6.7"
   }
 }

--- a/processor/api.py
+++ b/processor/api.py
@@ -1,0 +1,38 @@
+from flask import Flask, jsonify, request 
+from flask_restful import Resource, Api 
+
+import agents
+from router import simplerouter
+
+app = Flask(__name__) 
+api = Api(app) 
+
+class Processor(Resource):
+
+    def post(self): 
+        data = request.get_json()
+        doc_path = data.get('doc_path','')
+        model_path = data.get('model_path','')
+        embedding = data.get('embedding','')
+        prompt_yaml_path = data.get('prompt_yaml_path','')
+        query = data.get('query','')
+
+        router = simplerouter.SimpleRouter()
+        agent_list = agents.get_agent_list()
+        agent = router.select_agent(agent_list)(
+            model_path,
+            embedding,
+            doc_path,
+            prompt_yaml_path)
+
+        response = {
+            'answer': agent.perform(query)
+        }
+
+        return response, 201
+  
+
+api.add_resource(Processor, '/')
+
+if __name__ == '__main__': 
+    app.run(debug = False) 

--- a/processor/process.py
+++ b/processor/process.py
@@ -12,26 +12,36 @@ if __name__ == "__main__":
     dotenv_path = join(dirname(__file__), '../conf/.env')
     dotenv.load_dotenv(dotenv_path)
 
-    #Getting the environment configs
-    MODEL_PATH = os.environ.get("MODEL_PATH")
-    EMBEDDING = os.environ.get("EMBEDDING")
-    PROMPT_YAML_PATH = os.environ.get("PROMPT_YAML_PATH")
-
     #Reading the query from the argument passed as an input
     parser = argparse.ArgumentParser()
     parser.add_argument('--input', help='Query to be processed')
     parser.add_argument('--doc', help='Folder containing the source code')
+    parser.add_argument('--model_path', help='Path to the model hosted locally')
+    parser.add_argument('--embedding', help='Embedding to use')
+    parser.add_argument('--prompt_yaml_path', help='Prompt yaml path')
     args = parser.parse_args()
     query = args.input
     doc_path = args.doc
+
+    if doc_path is None:
+        doc_path = os.environ.get("DOC_PATH")
+    model_path = args.model_path
+    if model_path is None:
+        model_path = os.environ.get("MODEL_PATH")
+    embedding = args.embedding
+    if embedding is None:
+        embedding = os.environ.get("EMBEDDING")
+    prompt_yaml_path = args.prompt_yaml_path
+    if prompt_yaml_path is None:
+        prompt_yaml_path = os.environ.get("PROMPT_YAML_PATH")
 
     #Instantiation the agent to do the processing
     router = simplerouter.SimpleRouter()
     agent_list = agents.get_agent_list()
     agent = router.select_agent(agent_list)(
-        MODEL_PATH,
-        EMBEDDING,
+        model_path,
+        embedding,
         doc_path,
-        PROMPT_YAML_PATH)
+        prompt_yaml_path)
     
     print(agent.perform(query))

--- a/processor/process.py
+++ b/processor/process.py
@@ -23,16 +23,16 @@ if __name__ == "__main__":
     query = args.input
     doc_path = args.doc
 
-    if doc_path is None:
+    if doc_path is None or doc_path is '':
         doc_path = os.environ.get("DOC_PATH")
     model_path = args.model_path
-    if model_path is None:
+    if model_path is None or model_path is '':
         model_path = os.environ.get("MODEL_PATH")
     embedding = args.embedding
-    if embedding is None:
+    if embedding is None or embedding is '':
         embedding = os.environ.get("EMBEDDING")
     prompt_yaml_path = args.prompt_yaml_path
-    if prompt_yaml_path is None:
+    if prompt_yaml_path is None or prompt_yaml_path is '':
         prompt_yaml_path = os.environ.get("PROMPT_YAML_PATH")
 
     #Instantiation the agent to do the processing

--- a/processor/process.py
+++ b/processor/process.py
@@ -15,22 +15,23 @@ if __name__ == "__main__":
     #Getting the environment configs
     MODEL_PATH = os.environ.get("MODEL_PATH")
     EMBEDDING = os.environ.get("EMBEDDING")
-    DOC_PATH = os.environ.get("DOC_PATH")
     PROMPT_YAML_PATH = os.environ.get("PROMPT_YAML_PATH")
 
     #Reading the query from the argument passed as an input
     parser = argparse.ArgumentParser()
     parser.add_argument('--input', help='Query to be processed')
+    parser.add_argument('--doc', help='Folder containing the source code')
     args = parser.parse_args()
     query = args.input
-     
+    doc_path = args.doc
+
     #Instantiation the agent to do the processing
     router = simplerouter.SimpleRouter()
     agent_list = agents.get_agent_list()
     agent = router.select_agent(agent_list)(
         MODEL_PATH,
         EMBEDDING,
-        DOC_PATH,
+        doc_path,
         PROMPT_YAML_PATH)
     
     print(agent.perform(query))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ duckduckgo-search==4.4.3
 sentence-transformers==2.3.1
 chromadb==0.4.22
 PyYAML==6.0.1
+Flask==3.0.2
+Flask-RESTful==0.3.10


### PR DESCRIPTION
- Changed calling the python script to flask api
- To trigger the text generation select the text, right click and click on either `Generate Documentation Below` or `Generate Documentation Above` to generate documents above or below the selected text
- The input to the LLM is the selected text, trimmed.
- process.py can now take all arguments either via the .env file or command line arguments
- The vs code extension can take the below arguments via the settings.json file
  ```
    "jaac.modelPath": "",
    "jaac.embeddings": "",
    "jaac.prompt_yaml_path": "",
```